### PR TITLE
Fix require('mime')

### DIFF
--- a/liveConnect.lua
+++ b/liveConnect.lua
@@ -14,6 +14,7 @@ end;
 local socket = require("socket")
 local http = socket.http
 local ltn12 = require("ltn12")
+package.preload['mime.core'] = function() return {}; end;
 local mime = require("mime")
 
 -- Cache responses


### PR DESCRIPTION
The `mime` package requires mime.core, which is not available.

It's unclear which functions (if any) of mime.core are actually needed - so this code just stubs it out.

It may be that mime.core is actually needed, so if this doesn't work, this'll need revisiting.